### PR TITLE
Cities and City Endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,6 @@ PLATFORMS
   ruby
   x86_64-linux
 
-
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug

--- a/app/controllers/api/v1/cities_controller.rb
+++ b/app/controllers/api/v1/cities_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::CitiesController < ApplicationController 
+    def index
+        render json: CitySerializer.new(City.all)
+    end
+
+    def show
+        render json: CitySerializer.new(City.find(params[:id]))
+    end
+end

--- a/app/serializers/city_serializer.rb
+++ b/app/serializers/city_serializer.rb
@@ -1,0 +1,4 @@
+class CitySerializer
+  include JSONAPI::Serializer
+  attributes :name, :full_name, :summary, :scores, :details
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :cities, only: [:index]
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      resources :cities, only: [:index]
+      resources :cities, only: [:index, :show]
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,29 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_220_829_205_035) do
+ActiveRecord::Schema.define(version: 2022_08_29_205035) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'cities', force: :cascade do |t|
-    t.string 'name'
-    t.string 'full_name'
-    t.json 'summary'
-    t.json 'scores'
-    t.json 'details'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "cities", force: :cascade do |t|
+    t.string "name"
+    t.string "full_name"
+    t.json "summary"
+    t.json "scores"
+    t.json "details"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'searches', force: :cascade do |t|
-    t.string 'query'
-    t.bigint 'user_id'
-    t.index ['user_id'], name: 'index_searches_on_user_id'
+  create_table "searches", force: :cascade do |t|
+    t.string "query"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'username'
+  create_table "users", force: :cascade do |t|
+    t.string "username"
   end
 
-  add_foreign_key 'searches', 'users'
+  add_foreign_key "searches", "users"
 end

--- a/spec/factories/city.rb
+++ b/spec/factories/city.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :city do
+    name { Faker::Beer.name }
+    full_name {Faker::Lorem.sentence}
+    summary {Faker::Number.decimal(l_digits: 2)}
+    scores {Faker::Number.between(from: 1, to: 10)}
+    details {Faker::Number.between(from: 1, to: 10)}
+  end
+end

--- a/spec/requests/api/v1/cities_request.rb
+++ b/spec/requests/api/v1/cities_request.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Cities API' do
+    it "returns a list of cities" do
+        create_list(:city, 5)
+        get '/api/v1/cities'
+        
+        expect(response).to  be_successful
+        expect(response).to  have_http_status(200)
+
+        response_body = JSON.parse(response.body, symbolize_names: true)
+        cities = response_body[:data]
+
+        expect(cities.count).to eq(5) 
+        cities.each do |city|
+            expect(city).to have_key(:id)
+            expect(city).to have_key(:type)
+            expect(city).to have_key(:attributes)
+            expect(city[:attributes]).to have_key(:name)
+            expect(city[:attributes]).to have_key(:full_name)
+            expect(city[:attributes]).to have_key(:summary)
+            expect(city[:attributes]).to have_key(:scores)
+            expect(city[:attributes]).to have_key(:details)
+        end 
+    end
+end

--- a/spec/requests/api/v1/cities_request.rb
+++ b/spec/requests/api/v1/cities_request.rb
@@ -23,4 +23,19 @@ RSpec.describe 'Cities API' do
             expect(city[:attributes]).to have_key(:details)
         end 
     end
+
+    it "can return one city by its id" do
+        id = create(:city).id
+        get "/api/v1/cities/#{id}"
+
+        response_body = JSON.parse(response.body, symbolize_names: true)
+        city = response_body[:data]
+        expect(response).to have_http_status(200)
+        expect(city[:type]).to eq("city")
+        expect(city[:attributes]).to have_key(:name)
+        expect(city[:attributes]).to have_key(:full_name)
+        expect(city[:attributes]).to have_key(:summary)
+        expect(city[:attributes]).to have_key(:scores)
+        expect(city[:attributes]).to have_key(:details)
+    end
 end


### PR DESCRIPTION
### What does this PR do?
This adds two endpoints to request information for the cities table. One fore all cites (/api/v1/cities) and another for a single city (/api/v1/citites/:id)

### All tests passing?
- [x] Yes
- [ ] No

### Has this been tested on LOCALHOST?
- [x] Yes
- [ ] No
- Did something not work? If so, what was it?
