### PR TITLE
Change service routes to city_microservice

### DIFF
--- a/app/services/teleport_service.rb
+++ b/app/services/teleport_service.rb
@@ -1,32 +1,31 @@
 class TeleportService
-
   def self.conn
-    url = 'https://api.teleport.org/api/'
+    url = 'https://city-microservice.herokuapp.com/api/'
     Faraday.new(url: url)
   end
 
   def self.get_city_data(city)
-    response = conn.get("urban_areas/slug:#{city}/")
+    response = conn.get("#{city}")
     JSON.parse(response.body, symbolize_names: true)
   end
 
   def self.get_city_score_data(city)
-    response = conn.get("urban_areas/slug:#{city}/scores")
+    response = conn.get("#{city}/scores")
     JSON.parse(response.body, symbolize_names: true)
   end
 
   def self.get_all_urban_areas
-    response = conn.get("urban_areas/")
+    response = conn.get('urban_areas')
     JSON.parse(response.body, symbolize_names: true)
   end
 
   def self.get_city_image_data(city)
-    response = conn.get("urban_areas/slug:#{city}/images")
+    response = conn.get("#{city}/images")
     JSON.parse(response.body, symbolize_names: true)
   end
 
   def self.get_city_details_data(city)
-    response = conn.get("urban_areas/slug:#{city}/details")
+    response = conn.get("#{city}/details")
     JSON.parse(response.body, symbolize_names: true)
   end
 end


### PR DESCRIPTION
## Why is this PR necessary?
Needed to link rails services to Flask microservice.

## What does this PR do?
Changes all service routes to Flask microservice calls.

## What User story does this PR link to?
[Link Microservice](https://github.com/Dude-Hows-My-City/dhmc_be_rails/issues/24)