### PR TITLE
Add 'destory_all' to first line of rake task to reinstate database

### DIFF
--- a/lib/tasks/db_populate.rake
+++ b/lib/tasks/db_populate.rake
@@ -1,6 +1,7 @@
 namespace :db_populate do
 
   task :populate_cities => :environment do
+    City.destroy_all
     CityFacade.create_city_objects
     table = 'cities'
     auto_inc_val = 1


### PR DESCRIPTION
### Why is this PR necessary?
- Database on heroku was already populated with previous data, prior to including :salaries
- Needed to reinstate data with new fields

## What does this PR do?
- Adds City.destroy_all to top of rake task that fills the database to clear it before refilling it

