### PR TITLE
Update populate task to destory all Favorites

### DIFF
--- a/lib/tasks/db_populate.rake
+++ b/lib/tasks/db_populate.rake
@@ -1,6 +1,7 @@
 namespace :db_populate do
 
   task :populate_cities => :environment do
+    Favorite.destory_all
     City.destroy_all
     CityFacade.create_city_objects
     table = 'cities'


### PR DESCRIPTION
### Why is this PR necessary?
- Can't update cities database without emptying Favorites

## What does this PR do?
- Empties Favorites database when repopulating the Cities table

## Which User Story does this link to?
None